### PR TITLE
[#25] Fix: Add intl dependency and use intl DateTimeFormat

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "axios": "^0.21.1",
     "expo": "~42.0.1",
     "expo-status-bar": "~1.0.4",
+    "intl": "^1.2.5",
     "json-server": "^0.16.3",
     "react": "16.13.1",
     "react-dom": "16.13.1",

--- a/src/screens/Todo/TodoHeader.tsx
+++ b/src/screens/Todo/TodoHeader.tsx
@@ -6,7 +6,7 @@ import { getDay, getWeekday, getYearAndMonth } from 'utils/date';
 const TodoHeader: React.FC = () => {
   return (
     <View style={styles.header}>
-      <Text style={styles.day}>{getDay(today).slice(0, -1)}</Text>
+      <Text style={styles.day}>{getDay(today)}</Text>
       <View style={styles.date}>
         <Text>{getWeekday(today)}</Text>
         <Text>{getYearAndMonth(today)}</Text>
@@ -41,4 +41,4 @@ const styles = StyleSheet.create({
   },
 });
 
-const today = new Date().toISOString();
+const today = new Date();

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,25 +1,27 @@
+import { Platform } from 'react-native';
+
 const KO_KR_LOCALE = 'ko-KR';
 
-const SEOUL_TIMEZONE = 'Asia/Seoul';
+if (Platform.OS === 'android') {
+  require('intl');
+  require(`intl/locale-data/jsonp/${KO_KR_LOCALE}`);
+}
 
-export const getYearAndMonth = (date: string) => {
-  return new Date(date).toLocaleDateString(KO_KR_LOCALE, {
-    timeZone: SEOUL_TIMEZONE,
+export const getYearAndMonth = (date: Date) => {
+  return new Intl.DateTimeFormat(KO_KR_LOCALE, {
     year: 'numeric',
     month: 'long',
-  });
+  }).format(date);
 };
 
-export const getDay = (date: string) => {
-  return new Date(date).toLocaleDateString(KO_KR_LOCALE, {
-    timeZone: SEOUL_TIMEZONE,
+export const getDay = (date: Date) => {
+  return new Intl.DateTimeFormat(KO_KR_LOCALE, {
     day: 'numeric',
-  });
+  }).format(date);
 };
 
-export const getWeekday = (date: string) => {
-  return new Date(date).toLocaleDateString(KO_KR_LOCALE, {
-    timeZone: SEOUL_TIMEZONE,
+export const getWeekday = (date: Date) => {
+  return new Intl.DateTimeFormat(KO_KR_LOCALE, {
     weekday: 'long',
-  });
+  }).format(date);
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -4382,6 +4382,11 @@ internal-slot@^1.0.3:
     has "^1.0.3"
     side-channel "^1.0.4"
 
+intl@^1.2.5:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/intl/-/intl-1.2.5.tgz#82244a2190c4e419f8371f5aa34daa3420e2abde"
+  integrity sha1-giRKIZDE5Bn4Nx9ao02qNCDiq94=
+
 invariant@^2.2.2, invariant@^2.2.4:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"


### PR DESCRIPTION
## What I did

1. 날짜 locale 오류 해결
    - 해결방법: https://github.com/facebook/react-native/issues/19410#issuecomment-434232762
    - Intl.DateTimeFormat: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat

Closes #25 
