### PR TITLE
[#27] Use FlatList and remove ScrollView and map function

### DIFF
--- a/src/screens/Todo/TodoList.tsx
+++ b/src/screens/Todo/TodoList.tsx
@@ -1,25 +1,36 @@
 import React from 'react';
 import { useSelector } from 'react-redux';
-import { ScrollView, StyleSheet } from 'react-native';
+import {
+  FlatList,
+  ListRenderItemInfo,
+  ScrollView,
+  StyleSheet,
+} from 'react-native';
 import { RootState } from 'store/reducers';
 import TodoItem from './TodoItem';
+import { ITodo } from 'constants/todoTypes';
 
 const TodoList: React.FC = () => {
   const { todos } = useSelector((state: RootState) => state.todo);
 
+  const renderItem = ({ item }: ListRenderItemInfo<ITodo>) => (
+    <TodoItem todo={item} />
+  );
+
   return (
-    <ScrollView style={styles.scrollView}>
-      {todos.map((todo) => (
-        <TodoItem key={todo.id} todo={todo} />
-      ))}
-    </ScrollView>
+    <FlatList
+      style={styles.todoList}
+      data={todos}
+      renderItem={renderItem}
+      keyExtractor={(todo) => todo.id}
+    />
   );
 };
 
 export default TodoList;
 
 const styles = StyleSheet.create({
-  scrollView: {
+  todoList: {
     maxHeight: '70%',
   },
 });


### PR DESCRIPTION
## What I did

1. map 함수를 FlatList로 전환
    -  ListRenderItemInfo: https://stackoverflow.com/questions/52701665/typescript-react-native-flatlist-how-to-give-renderitem-the-correct-type-of-it
2. VirtualizedLists 관련 warning
    - 참고: https://nyxo.app/fixing-virtualizedlists-should-never-be-nested-inside-plain-scrollviews

![virtualized lists warning](https://user-images.githubusercontent.com/37607373/131724077-f444949c-c316-4b05-86fe-2f75338de656.png)




Closes #27
