### PR TITLE
[#29] Fix: Change software keyboard layout configuration

### DIFF
--- a/app.json
+++ b/app.json
@@ -23,7 +23,8 @@
       "adaptiveIcon": {
         "foregroundImage": "./assets/adaptive-icon.png",
         "backgroundColor": "#FFFFFF"
-      }
+      },
+      "softwareKeyboardLayoutMode": "pan"
     },
     "web": {
       "favicon": "./assets/favicon.png"

--- a/src/screens/Todo/TodoEditForm.tsx
+++ b/src/screens/Todo/TodoEditForm.tsx
@@ -47,6 +47,7 @@ const TodoEditForm: React.FC<ITodoEditFormProps> = ({
         onChangeText={handleChangeText}
         onSubmitEditing={handleSubmit}
         defaultValue={content}
+        autoFocus={true}
       />
       <CustomButton customStyle={styles.button} handlePress={handleSubmit}>
         <SvgXml

--- a/src/screens/Todo/TodoInputForm.tsx
+++ b/src/screens/Todo/TodoInputForm.tsx
@@ -34,6 +34,7 @@ const TodoInputForm: React.FC = () => {
         onChangeText={handleChange}
         onSubmitEditing={handleSubmit}
         defaultValue={content}
+        autoFocus={true}
       />
       <CustomButton customStyle={styles.button} handlePress={handleSubmit}>
         <SvgXml xml={PLUS_ICON_XML} width="100%" height="22" color="white" />


### PR DESCRIPTION
## What I did

1. 안드로이드 에뮬레이터에서 키보드가 닫히는 이슈 해결
    - 해결방법: https://forums.expo.dev/t/how-to-set-android-windowsoftinputmode-adjustresize-in-android-manifest-file/587/13
    - softwareKeyboardLayoutMode: https://docs.expo.dev/versions/v39.0.0/config/app/#softwarekeyboardlayoutmode
2. TextInput에 autoFocus 추가

![keyboard layout pan](https://user-images.githubusercontent.com/37607373/131768152-c035037c-6fc2-4e52-a426-4cfff2484f6c.gif)

Closes #29 
